### PR TITLE
fix: change homepage url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nuxtjs/markdownit",
   "version": "2.0.0",
-  "homepage": "https://github.com/nuxt-community/markdownit-module",
+  "repository": "nuxt-community/markdownit-module",
   "license": "MIT",
   "main": "dist/module.js",
   "types": "dist/module.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nuxtjs/markdownit",
   "version": "2.0.0",
-  "homepage": "nuxt-community/markdownit-module",
+  "homepage": "https://github.com/nuxt-community/markdownit-module",
   "license": "MIT",
   "main": "dist/module.js",
   "types": "dist/module.d.ts",


### PR DESCRIPTION
## issue
https://github.com/nuxt-community/markdownit-module/issues/32

## about
The link was invalid on npm site because the homepage link on the package.json was not valid.
I changed to valid homepage url.
