### PR TITLE
docs: add an  example for setting plugin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,17 @@ Using [markdownit-loader](https://github.com/nuxt-community/markdownit-loader) a
     breaks: true,
     use: [
       'markdown-it-div',
-      'markdown-it-attrs'
+      'markdown-it-attrs',
+      // if you need to set plugin option(s)
+      [
+        'markdown-it-link-attributes',
+        {
+          attrs: {
+            target: '_blank',
+            rel: 'noopener noreferrer',
+          },
+        },
+      ],
     ]
   }
 }


### PR DESCRIPTION
## issue 
https://github.com/nuxt-community/markdownit-module/issues/15

## about
Added a sample working example for setting plugin option(s) on nuxt.config.js.
...I also stuck to figure out how to pass options here😇 
Let me suggest using 'markdown-it-link-attributes' for clarification here.

